### PR TITLE
Progressive mesh (MANYFOLD_mesh_progressive) output support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,4 @@ source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 gemspec
+gem "mittsu-mesh_analysis", github: "manyfold3d/mittsu-mesh_analysis"

--- a/README.md
+++ b/README.md
@@ -37,6 +37,13 @@ You can also write binary files for simple single-mesh models:
 exporter.export(object, "output.glb", mode: :binary)
 ```
 
+## Progressive Meshes
+
+The binary GLTF exporter can create "progressive meshes" using the proposed
+[`MANYFOLD_mesh_progressive` GLTF extension](https://github.com/manyfold3d/glTF/tree/MANYFOLD_mesh_progressive/extensions/2.0/Vendor/MANYFOLD_mesh_progressive#readme). If you want to create these sort of meshes, you will need to install
+the `mittsu-mesh_analysis` gem and create a `Mittsu::MeshAnalysis::ProgressiveMesh` object, which you can
+then pass to `export` in the same way as above.
+
 ## About
 
 This code was originally written for [Manyfold](https://manyfold.app), supported by funding from [NLNet](https://nlnet.nl) and [NGI Zero](https://ngi.eu/ngi-projects/ngi-zero/).

--- a/examples/progressive_gltf_example.rb
+++ b/examples/progressive_gltf_example.rb
@@ -20,4 +20,4 @@ progressive = Mittsu::MeshAnalysis::ProgressiveMesh.new(object.geometry, object.
 progressive.progressify ratio: 0.75
 
 exporter = Mittsu::GLTFExporter.new
-exporter.export(progressive, File.expand_path("./mittsu-export.glb", File.dirname(__FILE__)), mode: :binary)
+exporter.export(progressive, File.expand_path("./progressive-export.glb", File.dirname(__FILE__)), mode: :binary)

--- a/examples/progressive_gltf_example.rb
+++ b/examples/progressive_gltf_example.rb
@@ -1,0 +1,23 @@
+$LOAD_PATH.unshift File.expand_path("../lib", __dir__)
+require "mittsu/gltf"
+begin
+  require "mittsu/mesh_analysis"
+rescue LoadError
+  puts "This example requires the mittsu-mesh_analysis gem, please install it."
+  return
+end
+
+loader = Mittsu::OBJLoader.new
+object = loader.load(File.expand_path("./mittsu.obj", File.dirname(__FILE__)))
+object.traverse do |x|
+  if x.is_a? Mittsu::Mesh
+    object = x
+    break
+  end
+end
+
+progressive = Mittsu::MeshAnalysis::ProgressiveMesh.new(object.geometry, object.material)
+progressive.progressify ratio: 0.75
+
+exporter = Mittsu::GLTFExporter.new
+exporter.export(progressive, File.expand_path("./mittsu-export.glb", File.dirname(__FILE__)), mode: :binary)

--- a/lib/mittsu/gltf/exporter.rb
+++ b/lib/mittsu/gltf/exporter.rb
@@ -120,12 +120,12 @@ module Mittsu
     end
 
     def add_mesh(mesh, mode:)
-      max_vertex_index = mesh.geometry.vertices.count
+      max_vertex_index = mesh.geometry.vertices.count - 1
 
       # Pack faces into an array
       face_buffer_length, face_buffer_offset = pack_into_buffer(
         elements: mesh.geometry.faces.map { |x| [x.a, x.b, x.c] },
-        format: (max_vertex_index >= (2**16)) ? "L<*" : "S<*"
+        format: (max_vertex_index > (2**16)) ? "L<*" : "S<*"
       )
       # Pack vertices in as floats
       vertex_buffer_length, vertex_buffer_offset = pack_into_buffer(
@@ -141,11 +141,11 @@ module Mittsu
           length: face_buffer_length,
           target: :element_array_buffer
         ),
-        component_type: (max_vertex_index >= (2**16)) ? :unsigned_int : :unsigned_short,
+        component_type: (max_vertex_index > (2**16)) ? :unsigned_int : :unsigned_short,
         count: mesh.geometry.faces.count * 3,
         type: "SCALAR",
         min: 0,
-        max: mesh.geometry.vertices.count - 1
+        max: max_vertex_index
       )
 
       # Add bufferView and accessor for vertices
@@ -158,7 +158,7 @@ module Mittsu
           target: :array_buffer
         ),
         component_type: :float,
-        count: mesh.geometry.vertices.count,
+        count: max_vertex_index + 1,
         type: "VEC3",
         min: mesh.geometry.bounding_box.min.elements,
         max: mesh.geometry.bounding_box.max.elements

--- a/lib/mittsu/gltf/exporter.rb
+++ b/lib/mittsu/gltf/exporter.rb
@@ -164,8 +164,8 @@ module Mittsu
         component_type: :float,
         count: max_vertex_index + 1,
         type: "VEC3",
-        min: mesh.geometry.bounding_box.min.elements,
-        max: mesh.geometry.bounding_box.max.elements
+        min: mesh.geometry.bounding_box.min.elements.map { |x| x.round 10 },
+        max: mesh.geometry.bounding_box.max.elements.map { |x| x.round 10 }
       )
       # Encode and store in buffers
       @buffers << ((mode == :ascii) ? {

--- a/lib/mittsu/gltf/exporter.rb
+++ b/lib/mittsu/gltf/exporter.rb
@@ -128,6 +128,16 @@ module Mittsu
       @binary_buffer = faces.flatten.pack(pack_string)
       face_buffer_offset = 0
       face_buffer_length = @binary_buffer.length
+
+      # Add padding to get to integer multiple of float size
+      padding = padding_required(@binary_buffer, stride: 4)
+      @binary_buffer += Array.new(padding, 0).pack("C*")
+      # Pack vertices in as floats
+      vertex_buffer_offset = @binary_buffer.length
+      vertices = mesh.geometry.vertices.map(&:elements)
+      @binary_buffer += vertices.flatten.pack("f*")
+      vertex_buffer_length = @binary_buffer.length - vertex_buffer_offset
+
       # Add bufferView and accessor for faces
       face_accessor_index = add_accessor(
         buffer_view: add_buffer_view(
@@ -142,14 +152,7 @@ module Mittsu
         min: 0,
         max: mesh.geometry.vertices.count - 1
       )
-      # Add padding to get to integer multiple of float size
-      padding = padding_required(@binary_buffer, stride: 4)
-      @binary_buffer += Array.new(padding, 0).pack("C*")
-      # Pack vertices in as floats
-      vertex_buffer_offset = @binary_buffer.length
-      vertices = mesh.geometry.vertices.map(&:elements)
-      @binary_buffer += vertices.flatten.pack("f*")
-      vertex_buffer_length = @binary_buffer.length - vertex_buffer_offset
+
       # Add bufferView and accessor for vertices
       mesh.geometry.compute_bounding_box
       vertex_accessor_index = add_accessor(

--- a/lib/mittsu/gltf/exporter.rb
+++ b/lib/mittsu/gltf/exporter.rb
@@ -42,7 +42,7 @@ module Mittsu
       @meshes = []
       @buffer_views = []
       @accessors = []
-      @binary_buffer = []
+      @binary_buffer = ""
     end
 
     def export(object, filename, mode: :ascii)
@@ -109,11 +109,11 @@ module Mittsu
 
     def pack_into_buffer(elements:, format:, pad: true)
       offset = @binary_buffer.length
-      data = elements.flatten.pack(format).chars
+      data = elements.flatten.pack(format)
       length = data.length
       if pad
         padding = padding_required(data, stride: 4)
-        data += Array.new(padding, 0).pack("C*").chars
+        data += Array.new(padding, 0).pack("C*")
       end
       @binary_buffer += data
       [length, offset]
@@ -123,20 +123,15 @@ module Mittsu
       max_vertex_index = mesh.geometry.vertices.count
 
       # Pack faces into an array
-      pack_string = (max_vertex_index >= (2**16)) ? "L<*" : "S<*"
-      faces = mesh.geometry.faces.map { |x| [x.a, x.b, x.c] }
-      @binary_buffer = faces.flatten.pack(pack_string)
-      face_buffer_offset = 0
-      face_buffer_length = @binary_buffer.length
-
-      # Add padding to get to integer multiple of float size
-      padding = padding_required(@binary_buffer, stride: 4)
-      @binary_buffer += Array.new(padding, 0).pack("C*")
+      face_buffer_length, face_buffer_offset = pack_into_buffer(
+        elements: mesh.geometry.faces.map { |x| [x.a, x.b, x.c] },
+        format: (max_vertex_index >= (2**16)) ? "L<*" : "S<*"
+      )
       # Pack vertices in as floats
-      vertex_buffer_offset = @binary_buffer.length
-      vertices = mesh.geometry.vertices.map(&:elements)
-      @binary_buffer += vertices.flatten.pack("f*")
-      vertex_buffer_length = @binary_buffer.length - vertex_buffer_offset
+      vertex_buffer_length, vertex_buffer_offset = pack_into_buffer(
+        elements: mesh.geometry.vertices.map(&:elements),
+        format: "f*"
+      )
 
       # Add bufferView and accessor for faces
       face_accessor_index = add_accessor(

--- a/lib/mittsu/gltf/exporter.rb
+++ b/lib/mittsu/gltf/exporter.rb
@@ -108,8 +108,10 @@ module Mittsu
     end
 
     def add_mesh(mesh, mode:)
+      max_vertex_index = mesh.geometry.vertices.count
+
       # Pack faces into an array
-      pack_string = (mesh.geometry.faces.count > (2**16)) ? "L<*" : "S<*"
+      pack_string = (max_vertex_index >= (2**16)) ? "L<*" : "S<*"
       faces = mesh.geometry.faces.map { |x| [x.a, x.b, x.c] }
       data = faces.flatten.pack(pack_string)
       # Add bufferView and accessor for faces
@@ -120,7 +122,7 @@ module Mittsu
           length: data.length,
           target: :element_array_buffer
         ),
-        component_type: (mesh.geometry.faces.count > (2**16)) ? :unsigned_int : :unsigned_short,
+        component_type: (max_vertex_index >= (2**16)) ? :unsigned_int : :unsigned_short,
         count: mesh.geometry.faces.count * 3,
         type: "SCALAR",
         min: 0,

--- a/lib/mittsu/gltf/exporter.rb
+++ b/lib/mittsu/gltf/exporter.rb
@@ -149,13 +149,13 @@ module Mittsu
         max: mesh.geometry.bounding_box.max.elements
       )
       # Encode and store in buffers
+      @binary_buffer = data
       @buffers << ((mode == :ascii) ? {
-        uri: "data:application/octet-stream;base64," + Base64.strict_encode64(data),
-        byteLength: data.length
+        uri: "data:application/octet-stream;base64," + Base64.strict_encode64(@binary_buffer),
+        byteLength: @binary_buffer.length
       } : {
-        byteLength: data.length
+        byteLength: @binary_buffer.length
       })
-      @binary_buffer = data if mode == :binary
       # Add mesh
       mesh_index = @meshes.count
       @meshes << {

--- a/lib/mittsu/gltf/exporter.rb
+++ b/lib/mittsu/gltf/exporter.rb
@@ -194,7 +194,7 @@ module Mittsu
       index
     end
 
-    def add_buffer_view(buffer:, offset:, length:, target: nil)
+    def add_buffer_view(buffer:, offset:, length:, target: nil, byte_stride: nil)
       # Check args
       raise ArgumentError.new("invalid GPU buffer target: #{target}") unless target.nil? || GPU_BUFFER_TYPES.key?(target)
       index = @buffer_views.count
@@ -202,8 +202,9 @@ module Mittsu
         buffer: buffer,
         byteOffset: offset,
         byteLength: length,
+        byteStride: byte_stride,
         target: GPU_BUFFER_TYPES[target]
-      }
+      }.compact
       index
     end
 

--- a/lib/mittsu/gltf/exporter.rb
+++ b/lib/mittsu/gltf/exporter.rb
@@ -36,6 +36,8 @@ module Mittsu
       if defined?(Mittsu::MeshAnalysis::ProgressiveMesh)
         self.class.include ProgressiveGLTFExporter
       end
+      @extensions_used = []
+      @extensions_required = []
       @node_indexes = []
       @nodes = []
       @buffers = []
@@ -59,6 +61,8 @@ module Mittsu
           json.generator "Mittsu-GLTF"
           json.version "2.0"
         end
+        json.extensionsRequired { json.array! @extensions_required.uniq } unless @extensions_required.empty?
+        json.extensionsUsed { json.array! @extensions_used.uniq } unless @extensions_used.empty?
         json.scene 0
         json.scenes [{
           nodes: @node_indexes

--- a/lib/mittsu/gltf/progressive_exporter.rb
+++ b/lib/mittsu/gltf/progressive_exporter.rb
@@ -91,8 +91,8 @@ module Mittsu
       y = mesh.vertex_splits.map { |vsplit| vsplit.displacement.y }.minmax
       z = mesh.vertex_splits.map { |vsplit| vsplit.displacement.z }.minmax
       [
-        [x[0], y[0], z[0]],
-        [x[1], y[1], z[1]]
+        [x[0].round(10), y[0].round(10), z[0].round(10)],
+        [x[1].round(10), y[1].round(10), z[1].round(10)]
       ]
     end
   end

--- a/lib/mittsu/gltf/progressive_exporter.rb
+++ b/lib/mittsu/gltf/progressive_exporter.rb
@@ -1,0 +1,10 @@
+require "jbuilder"
+require "base64"
+
+module Mittsu
+  module ProgressiveGLTFExporter
+    def add_progressive_mesh(obj)
+      raise NotImplementedError
+    end
+  end
+end

--- a/lib/mittsu/gltf/progressive_exporter.rb
+++ b/lib/mittsu/gltf/progressive_exporter.rb
@@ -3,8 +3,97 @@ require "base64"
 
 module Mittsu
   module ProgressiveGLTFExporter
-    def add_progressive_mesh(obj)
-      raise NotImplementedError
+    def add_progressive_mesh(mesh)
+      # Add extension to used
+      # but not required, as the base mesh can be rendered without the vertex split stream
+      @extensions_used << "MANYFOLD_mesh_progressive"
+
+      # First, add the base mesh in the standard way
+      index = add_mesh(mesh, mode: :binary)
+
+      offset = @binary_buffer.length
+      mesh.vertex_splits.each do |vsplit|
+        # Add vertices and pad
+        @binary_buffer += [vsplit.vertex, vsplit.left, vsplit.right].pack("L<*")
+        @binary_buffer += Array.new(padding_required(@binary_buffer, stride: 4), 0).pack("C*")
+        # Add displacement vector
+        @binary_buffer += vsplit.displacement.elements.pack("f*")
+        @binary_buffer += Array.new(padding_required(@binary_buffer, stride: 4), 0).pack("C*")
+      end
+      length = @binary_buffer.length - offset
+      # Update buffer length
+      buffer_index = @buffers.length - 1
+      @buffers[buffer_index][:byteLength] = @binary_buffer.length
+
+      stride = length / mesh.vertex_splits.length
+
+      # Create the pair of interleaved accessors
+
+      min, max = progressive_vertex_bounds(mesh)
+      progressive_vertex_accessor_index = add_accessor(
+        buffer_view: add_buffer_view(
+          buffer: buffer_index,
+          offset: offset,
+          length: length,
+          byte_stride: stride,
+          target: :array_buffer
+        ),
+        component_type: :unsigned_int,
+        count: mesh.vertex_splits.count,
+        type: "VEC3",
+        min: min,
+        max: max
+      )
+
+      min, max = progressive_displacement_bounds(mesh)
+      progressive_displacement_accessor_index = add_accessor(
+        buffer_view: add_buffer_view(
+          buffer: buffer_index,
+          offset: offset + 12,
+          length: length - 12,
+          byte_stride: stride,
+          target: :array_buffer
+        ),
+        component_type: :float,
+        count: mesh.vertex_splits.count,
+        type: "VEC3",
+        min: min,
+        max: max
+      )
+
+      # Add in mesh extension data
+      @meshes[index][:extensions] = {
+        MANYFOLD_mesh_progressive: {
+          attributes: {
+            POSITION: progressive_displacement_accessor_index
+          },
+          indices: progressive_vertex_accessor_index
+        }
+      }
+
+      index
+    end
+
+    private
+
+    def progressive_vertex_bounds(mesh)
+      vertex = mesh.vertex_splits.map(&:vertex).minmax
+      left = mesh.vertex_splits.map(&:left).minmax
+      right = mesh.vertex_splits.map(&:right).minmax
+      [
+        [vertex[0], left[0], right[0]],
+        [vertex[1], left[1], right[1]]
+      ]
+    end
+
+    def progressive_displacement_bounds(mesh)
+      x = mesh.vertex_splits.map { |vsplit| vsplit.displacement.x }.minmax
+      y = mesh.vertex_splits.map { |vsplit| vsplit.displacement.y }.minmax
+      z = mesh.vertex_splits.map { |vsplit| vsplit.displacement.z }.minmax
+      [
+        [x[0], y[0], z[0]],
+        [x[1], y[1], z[1]]
+      ]
     end
   end
 end

--- a/mittsu-gltf.gemspec
+++ b/mittsu-gltf.gemspec
@@ -24,6 +24,9 @@ Gem::Specification.new do |spec|
   spec.add_dependency "mittsu", "~> 0.4"
   spec.add_dependency "jbuilder", "~> 2.13"
 
+  # Optional, but required in dev for test running
+  spec.add_development_dependency "mittsu-mesh_analysis"
+
   spec.add_development_dependency "rake", "~> 13.2"
   spec.add_development_dependency "rspec", "~> 3.13"
   spec.add_development_dependency "standard", "~> 1.41"

--- a/spec/lib/mittsu/gltf_exporter_spec.rb
+++ b/spec/lib/mittsu/gltf_exporter_spec.rb
@@ -185,7 +185,6 @@ RSpec.describe Mittsu::GLTFExporter do
     end
 
     it "buffer zero is 44 bytes long in total (6 + 2 padding + 36)" do
-      puts @json.inspect
       expect(@json.dig("buffers", 0, "byteLength")).to eq 44
     end
 

--- a/spec/lib/mittsu/progressive_gltf_exporter_spec.rb
+++ b/spec/lib/mittsu/progressive_gltf_exporter_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe Mittsu::ProgressiveGLTFExporter do
 
   context "when reading chunk 1" do
     let(:header) { file.slice(1244, 8).unpack("L<*") }
-    let(:vsplit_data) { file.slice(2680, 2568) }
+    let(:vsplit_data) { file.slice(2680..-1) }
 
     it "specifies correct chunk length" do
       expect(header[0]).to eq 3996

--- a/spec/lib/mittsu/progressive_gltf_exporter_spec.rb
+++ b/spec/lib/mittsu/progressive_gltf_exporter_spec.rb
@@ -25,10 +25,6 @@ RSpec.describe Mittsu::ProgressiveGLTFExporter do
   context "when reading chunk 0" do
     let(:header) { file.slice(12, 8).unpack("L<*") }
 
-    it "specifies correct padded chunk length" do
-      expect(header[0]).to eq 1168
-    end
-
     it "specifies that this is a JSON chunk" do
       expect(header[1]).to eq 0x4E4F534A # "JSON" as an int
     end
@@ -120,9 +116,13 @@ RSpec.describe Mittsu::ProgressiveGLTFExporter do
     end
   end
 
-  context "when reading chunk 1" do
-    let(:header) { file.slice(1188, 8).unpack("L<*") }
-    let(:vsplit_data) { file.slice(2624..-1) }
+  context "when reading chunk 1" do # rubocop:disable RSpec/MultipleMemoizedHelpers
+    let(:json_chunk_length) { file.slice(12, 8).unpack1("L<") }
+    let(:header) { file.slice(json_chunk_length + 12 + 8, 8).unpack("L<*") }
+    let(:vsplit_data) {
+      offset = json_chunk_length + 12 + 8 + 8 + 1428
+      file.slice(offset..-1)
+    }
 
     it "specifies correct chunk length" do
       expect(header[0]).to eq 3996

--- a/spec/lib/mittsu/progressive_gltf_exporter_spec.rb
+++ b/spec/lib/mittsu/progressive_gltf_exporter_spec.rb
@@ -1,0 +1,140 @@
+# rubocop:todo RSpec/InstanceVariable
+require "tmpdir"
+require "mittsu/mesh_analysis"
+
+RSpec.describe Mittsu::ProgressiveGLTFExporter do
+  let(:mesh) do
+    mesh = Mittsu::MeshAnalysis::ProgressiveMesh.new(
+      Mittsu::SphereGeometry.new(2.0, 16, 8)
+    )
+    mesh.progressify
+    mesh.name = "mesh"
+    mesh
+  end
+  let(:file) { File.binread(@filename) }
+  let(:json) { JSON.parse(file.slice(20, header[0])) }
+
+  around do |example|
+    Dir.mktmpdir do |dir|
+      @filename = File.join("test.glb")
+      Mittsu::GLTFExporter.new.export(mesh, @filename, mode: :binary)
+      example.call
+    end
+  end
+
+  context "when reading chunk 0" do
+    let(:header) { file.slice(12, 8).unpack("L<*") }
+
+    it "has same buffer length as chunk 1 length" do
+      expect(json.dig("buffers", 0, "byteLength")).to eq 3996
+    end
+
+    it "specifies extension" do
+      expect(json.dig("extensionsUsed", 0)).to eq "MANYFOLD_mesh_progressive"
+    end
+
+    context "when checking vertex data bufferView" do
+      it "includes bufferView that references the main buffer" do
+        expect(json.dig("bufferViews", 2, "buffer")).to eq 0
+      end
+
+      it "has correct offset for the bufferView" do
+        expect(json.dig("bufferViews", 2, "byteOffset")).to eq 1428
+      end
+
+      it "has correct total length for the bufferView" do
+        expect(json.dig("bufferViews", 2, "byteLength")).to eq(107 * 24)
+      end
+
+      it "has correct stride for the bufferView" do
+        expect(json.dig("bufferViews", 2, "byteStride")).to eq 24
+      end
+    end
+
+    context "when checking displacement data bufferView" do
+      it "includes bufferView that references the main buffer" do
+        expect(json.dig("bufferViews", 3, "buffer")).to eq 0
+      end
+
+      it "is offset by 12 bytes from the vertex data" do
+        expect(json.dig("bufferViews", 3, "byteOffset")).to eq json.dig("bufferViews", 2, "byteOffset") + 12
+      end
+
+      it "is 12 bytes shorter than the vertex data bufferView" do
+        expect(json.dig("bufferViews", 3, "byteLength")).to eq json.dig("bufferViews", 2, "byteLength") - 12
+      end
+
+      it "has correct stride for the bufferView" do
+        expect(json.dig("bufferViews", 3, "byteStride")).to eq 24
+      end
+    end
+
+    context "when checking vertex data accessor" do
+      it "references correct bufferView" do
+        expect(json.dig("accessors", 2, "bufferView")).to eq 2
+      end
+
+      it "uses unsigned ints" do
+        expect(json.dig("accessors", 2, "componentType")).to eq 5125
+      end
+
+      it "specifies number of vertex splits" do
+        expect(json.dig("accessors", 2, "count")).to eq 107
+      end
+    end
+
+    context "when checking displacement data accessor" do
+      it "references correct bufferView" do
+        expect(json.dig("accessors", 3, "bufferView")).to eq 3
+      end
+
+      it "uses floats" do
+        expect(json.dig("accessors", 3, "componentType")).to eq 5126
+      end
+
+      it "specifies number of vertex splits" do
+        expect(json.dig("accessors", 3, "count")).to eq 107
+      end
+    end
+
+    context "when inspecting mesh structure" do
+      it "includes extension data" do
+        expect(json.dig("meshes", 0, "extensions", "MANYFOLD_mesh_progressive")).not_to be_nil
+      end
+
+      it "references vertex accessor" do
+        expect(json.dig("meshes", 0, "extensions", "MANYFOLD_mesh_progressive", "indices")).to eq 2
+      end
+
+      it "references displacement accessor" do
+        expect(json.dig("meshes", 0, "extensions", "MANYFOLD_mesh_progressive", "attributes", "POSITION")).to eq 3
+      end
+    end
+  end
+
+  context "when reading chunk 1" do
+    let(:header) { file.slice(1244, 8).unpack("L<*") }
+    let(:vsplit_data) { file.slice(2680, 2568) }
+
+    it "specifies correct chunk length" do
+      expect(header[0]).to eq 3996
+    end
+
+    it "specifies that this is a BIN chunk" do
+      expect(header[1]).to eq 0x004E4942 # "BIN" as an int
+    end
+
+    it "includes vertex split data" do # rubocop:todo RSpec/ExampleLength
+      vsplit = mesh.vertex_splits.first
+      expected = [
+        vsplit.vertex, vsplit.left, vsplit.right,
+        vsplit.displacement.x, vsplit.displacement.y, vsplit.displacement.z
+      ]
+      vsplit_data.unpack("L<L<L<fff").zip(expected).each do |x|
+        expect(x[0]).to be_within(1e-6).of(x[1])
+      end
+    end
+  end
+end
+
+# rubocop:enable RSpec/InstanceVariable

--- a/spec/lib/mittsu/progressive_gltf_exporter_spec.rb
+++ b/spec/lib/mittsu/progressive_gltf_exporter_spec.rb
@@ -25,6 +25,14 @@ RSpec.describe Mittsu::ProgressiveGLTFExporter do
   context "when reading chunk 0" do
     let(:header) { file.slice(12, 8).unpack("L<*") }
 
+    it "specifies correct padded chunk length" do
+      expect(header[0]).to eq 1168
+    end
+
+    it "specifies that this is a JSON chunk" do
+      expect(header[1]).to eq 0x4E4F534A # "JSON" as an int
+    end
+
     it "has same buffer length as chunk 1 length" do
       expect(json.dig("buffers", 0, "byteLength")).to eq 3996
     end
@@ -113,8 +121,8 @@ RSpec.describe Mittsu::ProgressiveGLTFExporter do
   end
 
   context "when reading chunk 1" do
-    let(:header) { file.slice(1244, 8).unpack("L<*") }
-    let(:vsplit_data) { file.slice(2680..-1) }
+    let(:header) { file.slice(1188, 8).unpack("L<*") }
+    let(:vsplit_data) { file.slice(2624..-1) }
 
     it "specifies correct chunk length" do
       expect(header[0]).to eq 3996


### PR DESCRIPTION
Saves using `MANYFOLD_mesh_progressive` extension (see https://github.com/manyfold3d/glTF/tree/MANYFOLD_mesh_progressive/extensions/2.0/Vendor/MANYFOLD_mesh_progressive#readme).

Autodetects if `mittsu-mesh_analysis` gem is available, and only enables progressive code if it's there.

resolves #2 